### PR TITLE
Add New Feature Enable/Disable Past Date's

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For Maven:
 | text_size_date             | Dimension | Date text size                     |
 | header_bg                  | Drawable  | Header background                  |
 | week_offset                | Dimension | To set week start day offset                  |
+| enable_past_date           | Boolean   | Enable/Disable past date's by default its value its false               |
 
 
 **Set callbacks**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.1.2'
     testImplementation 'junit:junit:4.12'
-//    implementation project(':awesome-calendar')
-    compile 'com.archit.calendar:awesome-calendar:1.1.2'
+    implementation project(':awesome-calendar')
+//    compile 'com.archit.calendar:awesome-calendar:1.1.2'
     implementation 'com.android.support:cardview-v7:27.1.1'
 
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -21,6 +21,7 @@
             android:layout_height="wrap_content"
             custom:calendar_tag="Test"
             custom:disable_date_color="#ABABAB"
+            custom:enable_past_date="false"
             custom:header_bg="@drawable/calendar_header"
             custom:range_color="@color/range_bg_color_app"
             custom:selected_date_circle_color="@color/selected_date_circle_color_app"

--- a/awesome-calendar/src/main/java/com/archit/calendardaterangepicker/customviews/DateRangeMonthView.java
+++ b/awesome-calendar/src/main/java/com/archit/calendardaterangepicker/customviews/DateRangeMonthView.java
@@ -264,11 +264,10 @@ public class DateRangeMonthView extends LinearLayout {
 
         if (currentCalendarMonth.get(Calendar.MONTH) != calendar.get(Calendar.MONTH)) {
             hideDayContainer(container);
-        } else if (today.after(calendar) && (today.get(Calendar.DAY_OF_YEAR) != calendar.get(Calendar.DAY_OF_YEAR))) {
+        } else if (today.after(calendar) && (today.get(Calendar.DAY_OF_YEAR) != calendar.get(Calendar.DAY_OF_YEAR)) && !calendarStyleAttr.isEnabledPastDates()) {
             disableDayContainer(container);
             container.tvDate.setText(String.valueOf(date));
         } else {
-
             @DateRangeCalendarManager.RANGE_TYPE
             int type = dateRangeCalendarManager.checkDateRange(calendar);
             if (type == DateRangeCalendarManager.RANGE_TYPE.START_DATE || type == DateRangeCalendarManager.RANGE_TYPE.LAST_DATE) {

--- a/awesome-calendar/src/main/java/com/archit/calendardaterangepicker/models/CalendarStyleAttr.java
+++ b/awesome-calendar/src/main/java/com/archit/calendardaterangepicker/models/CalendarStyleAttr.java
@@ -23,6 +23,7 @@ public class CalendarStyleAttr {
     private float textSizeTitle, textSizeWeek, textSizeDate;
     private boolean shouldEnabledTime = false;
     private int weekOffset = 0;
+    private boolean enabledPastDates = false;
 
     public CalendarStyleAttr(Context context) {
         setDefAttributes(context);
@@ -84,6 +85,7 @@ public class CalendarStyleAttr {
                 rangeStripColor = ta.getColor(R.styleable.DateRangeMonthView_range_color, rangeStripColor);
                 selectedDateCircleColor = ta.getColor(R.styleable.DateRangeMonthView_selected_date_circle_color, selectedDateCircleColor);
                 shouldEnabledTime = ta.getBoolean(R.styleable.DateRangeMonthView_enable_time_selection, false);
+                enabledPastDates = ta.getBoolean(R.styleable.DateRangeMonthView_enable_past_date,false);
 
                 textSizeTitle = ta.getDimension(R.styleable.DateRangeMonthView_text_size_title, textSizeTitle);
                 textSizeWeek = ta.getDimension(R.styleable.DateRangeMonthView_text_size_week, textSizeWeek);
@@ -216,6 +218,14 @@ public class CalendarStyleAttr {
 
     public int getWeekOffset() {
         return weekOffset;
+    }
+
+    public boolean isEnabledPastDates() {
+        return enabledPastDates;
+    }
+
+    public void setEnabledPastDates(boolean enabledPastDates) {
+        this.enabledPastDates = enabledPastDates;
     }
 
     /**

--- a/awesome-calendar/src/main/res/values/attrs.xml
+++ b/awesome-calendar/src/main/res/values/attrs.xml
@@ -17,7 +17,7 @@
         <attr name="header_bg" format="integer" />
         <attr name="calendar_tag" format="string" />
         <attr name="week_offset" format="integer" />
+        <attr name="enable_past_date" format="boolean" />
     </declare-styleable>
-
 
 </resources>


### PR DESCRIPTION
Add new Tag to enable or disable past date's
Tag: enable_past_date  Boolean by default its value its false

For Issue : [ #4](https://github.com/ArchitShah248/CalendarDateRangePicker/issues/4)