### PR TITLE
removed "app_name" and application label to avoid conflicts

### DIFF
--- a/awesome-calendar/src/main/AndroidManifest.xml
+++ b/awesome-calendar/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
 
     <application
         android:allowBackup="true"
-        android:label="@string/app_name"
         android:supportsRtl="true">
 
     </application>

--- a/awesome-calendar/src/main/res/values-pt-rBR/strings.xml
+++ b/awesome-calendar/src/main/res/values-pt-rBR/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">AwesomeCalendar</string>
-
     <string name="cdrp_mon">Seg</string>
     <string name="cdrp_tue">Ter</string>
     <string name="cdrp_wed">Qua</string>

--- a/awesome-calendar/src/main/res/values/strings.xml
+++ b/awesome-calendar/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
-    <string name="app_name">AwesomeCalendar</string>
-
     <string name="cdrp_mon">Mon</string>
     <string name="cdrp_tue">Tue</string>
     <string name="cdrp_wed">Wed</string>


### PR DESCRIPTION
The name of the name application was being changed by the library's name since they were using the same resource name (app_name), so I removed the application label in the library's manifest and the "app_name" strings. The library doesn't need them anyway.